### PR TITLE
Add Optional Auth Token Support

### DIFF
--- a/src/OllamaClient.php
+++ b/src/OllamaClient.php
@@ -16,10 +16,13 @@ class OllamaClient
     /**
      * @param string $host
      */
-    public function __construct(string $host = 'http://localhost:11434')
+    public function __construct(string $host = 'http://localhost:11434', string $apiKey = '')
     {
         $this->guzzleClient = new Client([
             'base_uri' => "$host/api/",
+            'headers' => [
+                'Authorization' => "Bearer $apiKey",
+            ],
         ]);
     }
 


### PR DESCRIPTION
For instances that require an auth token, this adds the possibility to init the client with

`$client = \ArdaGnsrn\Ollama\Ollama::client('http://localhost:11434','API_KEY');`