### PR TITLE
Fix models/list - "families" may be null

### DIFF
--- a/src/Responses/Models/ListModelsModelDetailsResponse.php
+++ b/src/Responses/Models/ListModelsModelDetailsResponse.php
@@ -36,7 +36,7 @@ class ListModelsModelDetailsResponse implements ResponseContract
             family: $attributes['family'],
             parameterSize: $attributes['parameter_size'],
             quantizationLevel: $attributes['quantization_level'],
-            families: $attributes['families'],
+            families: $attributes['families'] ?? [],
             parentModel: $attributes['parent_model'],
         );
     }


### PR DESCRIPTION
As the API doc states, "families" may be null.

See https://github.com/ollama/ollama/blob/main/docs/api.md#list-local-models